### PR TITLE
CI: Update to new output location

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,17 +21,17 @@ jobs:
 
       - run: ssh-keyscan 209.97.129.212 >> ~/.ssh/known_hosts
 
-      - run: ssh -tt david2@209.97.129.212 'rm -rf /var/www/manx-corpus/OpenData/{*,.*}'
+      - run: ssh -tt david2@209.97.129.212 'rm -rf /var/www/manx-corpus/CorpusSearch/OpenData/{*,.*}'
         continue-on-error: true
         timeout-minutes: 4
       
       - name: Copy Data to server
-        run: scp -r "$GITHUB_WORKSPACE/OpenData" david2@209.97.129.212:/var/www/manx-corpus/
+        run: scp -r "$GITHUB_WORKSPACE/OpenData" david2@209.97.129.212:/var/www/manx-corpus/CorpusSearch/
         timeout-minutes: 20
         
         # ignore the output of rm -rf and continue
       - name: Refresh Closed Data from GitHub Repo
-        run: ssh -t david2@209.97.129.212 'rm -rf /var/www/manx-corpus/ClosedData/{*,.*} || cd ~/corpus-search-data-private && git pull origin master && cp -r ~/corpus-search-data-private/ClosedData /var/www/manx-corpus/'
+        run: ssh -t david2@209.97.129.212 'rm -rf /var/www/manx-corpus/CorpusSearch/ClosedData/{*,.*} || cd ~/corpus-search-data-private && git pull origin master && cp -r ~/corpus-search-data-private/ClosedData /var/www/manx-corpus/CorpusSearch/'
                 
       - name: Rebuild
         run: ssh -t david2@209.97.129.212 'sudo /bin/systemctl stop manx-corpus.service && cd /var/www/manx-corpus/ && dotnet publish'


### PR DESCRIPTION
With automatic publishing, we moved to `manx-corpus/CorpusSearch` for the root

* `/var/www/manx-corpus/CorpusSearch/OpenData`
* `/var/www/manx-corpus/CorpusSearch/ClosedData`