### PR TITLE
feat: a trailing space is invalid for a directory (Windows)

### DIFF
--- a/TestUtil/InvalidPathChecker.cs
+++ b/TestUtil/InvalidPathChecker.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
+﻿using System.Linq;
 
 namespace Manx_Search_Data.TestUtil
 {
@@ -10,11 +8,12 @@ namespace Manx_Search_Data.TestUtil
         {
             // This isn't perfect, but we're not protecting against malicious uses.
             // Invalid on Windows
-            var invalidCharacters = "<>:;\"|?*".Select(c => c).ToHashSet();
+            var invalidCharacters = "<>:\"|?*".Select(c => c).ToHashSet();
 
             var pathToTest = path.Substring(4); //C:// should be trimmed - matches :
 
-            return pathToTest.All(c => !invalidCharacters.Contains(c)) && !GetParentName(path).TrimEnd().EndsWith('.');
+            string parentName = GetParentName(path);
+            return pathToTest.All(c => !invalidCharacters.Contains(c)) && !parentName.EndsWith(" ") && !path.TrimEnd().EndsWith('.');
         }
 
         private static string GetParentName(string path)

--- a/Tests.cs
+++ b/Tests.cs
@@ -72,7 +72,9 @@ namespace Manx_Search_Data
             AssertInvalid("OpenData/secular printed material 1750-1900/O Yee gloyroil, Hood’s ta shin geam. /document.csv");
             AssertValid("OpenData/secular printed material 1750-1900/O Yee gloyroil, Hood’s ta shin geam/document.csv");
             AssertInvalid("OpenData/secular printed material 1750-1900/The Exiles of Mona; ‘Dy Darragh yn Laa’ /document.csv");
-            AssertValid("OpenData/secular printed material 1750-1900/The Exiles of Mona ‘Dy Darragh yn Laa’ /document.csv");
+            AssertValid("OpenData/secular printed material 1750-1900/The Exiles of Mona ‘Dy Darragh yn Laa’/document.csv");
+            AssertInvalid("OpenData/secular printed material 1750-1900/Yn Arrane-Caggee-Anmormonagh /document.csv");
+            AssertValid("OpenData/secular printed material 1750-1900/Yn Arrane-Caggee-Anmormonagh/document.csv");
         }
 
         [Theory]


### PR DESCRIPTION
Turns out Semicolons were valid

Fixes #609