### PR TITLE
fix: validate 'Manx Original'/'English Original" column

### DIFF
--- a/OpenData/NedBeg/Te feer ymmyrchagh/document.csv
+++ b/OpenData/NedBeg/Te feer ymmyrchagh/document.csv
@@ -1,4 +1,4 @@
-﻿Manx,English,Original Manx,Noes
+﻿Manx,English,Manx Original,Noes
 "Te feer ymmyrçhagh dooin dy ve toiggal cre’d er ta’n sauçhys ain lhie. Dy beagh shin faagit dooin hene, yinnagh shin son shickerys tuittym. Agh bannit dy row Jee, ta shin ayns laueyn saualtagh graihagh, as ta eshyn abyl dy reayl shin voish tuittym.","It is very necessary for us to be understanding that which upon our safety depends. If we were left to ourselves, we would surely fall. But, God be blessed, we are in the hands of a loving saviour, and he is able to keep us from falling. ","Te feer ymmyrçhagh dooin dy ve toiggal cre’d ta’n sauçhys ain lhie. Dy beagh shin faagit dooin hene, yinnagh shin son shickerys tuittym. Agh bannit dy row Jee, ta shin ayns laueyn saualtagh graihagh, as ta eshyn abyl dy reayl shin voish tuittym.",
 ,,,
 "     Vod shin treishteil yn Saualtagh shoh? Bee shiu ec fea ersyn ny lomarcan, ny, vel Satan sonsheraght dooytyn nish as reesht lurg ooilley dy vod shiu laa ennagh tuittym as ve caillit?","Can we we trust this saviour? Will you be resting on him alone, or is Satan whispering doubts now and again’ that after all you can one day fall and be lost? ",,

--- a/OpenData/temperence - methodist/Ruleyn/document.csv
+++ b/OpenData/temperence - methodist/Ruleyn/document.csv
@@ -1,4 +1,4 @@
-﻿English,Manx,Original Manx,Notes
+﻿English,Manx,Manx Original,Notes
 ,,,
 THE ,RULEYN.,,
 "NATURE, DESIGN,",YN,,

--- a/TestUtil/DocumentLineMap.cs
+++ b/TestUtil/DocumentLineMap.cs
@@ -1,15 +1,29 @@
-﻿using CsvHelper.Configuration;
+﻿using System;
+using CsvHelper.Configuration;
 
 namespace Manx_Search_Data.TestUtil
 {
     public class DocumentLineMap : ClassMap<DocumentLine>
     {
+        private readonly string[] _invalidFieldNames = { "Original Manx", "Original English" };
         public DocumentLineMap()
         {
             Map(m => m.English);
             Map(m => m.Manx);
-            Map(m => m.Notes).Optional();
             Map(m => m.Page).Optional();
+            Map(m => m.Notes).Optional().Convert(args =>
+            {
+                // arbitrary validation of fields
+                foreach (var invalidFieldName in _invalidFieldNames)
+                {
+                    if (args.Row.TryGetField<string>(invalidFieldName, out _))
+                    {
+                        throw new ArgumentException($"Invalid Field: ${invalidFieldName}. Should be 'X Original'");
+                    }
+                }
+                args.Row.TryGetField("Notes", out string notes);
+                return notes;
+            });
         }
     }
 }


### PR DESCRIPTION
Occasionally called Original X, in which it isn't handled