### PR TITLE
Manx Dishes

### DIFF
--- a/OpenData/secular printed material - 1900 - 1921/Manx Dishes/document.csv
+++ b/OpenData/secular printed material - 1900 - 1921/Manx Dishes/document.csv
@@ -1,0 +1,399 @@
+﻿Manx,English
+,MANX DISHES (p172 – 203)
+BROISH VAINNEY,MILK BROISH.
+,"Mrs. Creer, Ballachurry, Greeba."
+Gow lieh berreen dy arran-oarn as çhiow eh trooid ayns ny smaragyn ; eisht brish eh ayns meeryn veggey as cur ayns jyst dy vainney-geayr. ,"Take half a cake of barley bread 2 or 3 days old, toast it well, and when thoroughly warm break into small pieces and put into a basin. "
+Lhig da shassoo son tammylt beg roish ee.,Let it stand for five minutes before eating.
+COWREE.,COWREE.
+,"Mrs. T. Moore, Brookfield, Port Erin."
+Jeant jeh meein-corkey beihlt meein.,Made of fine oatmeal.
+Cur yn meinn ayns crockan as coodjagh [sic] harrish lesh ushtey gys daa oarlagh ; eisht mastey as faagail eh three laa. ,"Put the meal in a crock and cover with about two inches of water, mix, and leave it three days. "
+"Eisht cur eh trooid shollane as cur eh ayns pash yiarn, broie son oor. ",Then put it through a sieve and into an iron pot. Boil for an hour. 
+Dy ve eeit lesh bainney millish.,To be eaten with new milk.
+COWREE.,COWREE.
+,"Miss I. Cannell, Michael."
+,"Put some oatmeal — about 8 tablespoonfuls to 1 qrt. of cold water — into an earthenware vessel, let it stand through a hair sieve. Pour the strained part into a saucepan, set over a moderate fire, and stir all the time till it thickens. Boil 5 minutes or more, and just before reomoving from the fire add a little salt. To be served as porridge with milk or cream, or if cold with hot milk. "
+COWREE.,COWREE.
+,"Mr. C. Roeder, Manchester."
+(Geidit voish ny mooinjer-vegger.),(Recipe filched from the fairies.)
+Gow mysh lieh tubbag bleeaystyn y veinn-corkey as cur eh ayns crockan nuy laa coodit lesh ushtey — te eisht enmysit ushtey gial. ,"Steep the husks of a bushel of oats, with a handful or two of fine oatmeal, for 9 days in sufficient water to cover ; when it has become bitter run the water through a sieve to remove the husks then it is like white water. "
+"Te eisht currit ayns pash vooar er yn aile, as te çhyndaait mygeayrt lesh maidjey-mastee gys te er n’aase çheu. ","Now fill the biggest pot you have in the house with it, stir it with a pot-stick all the time it it on the fire, unti it becomes thick and solid. "
+Eisht te aarloo dy ve folmit ayns claaryn dy ve eeit lesh bainney.,When it is quite cold boil it with milk and serve.
+FUMBYREE.,SHELLED BARLEY PORRIDGE
+,"Miss K. Quirk, Patrick Street, Peel."
+Oarn skihlt.,Shelled barley.
+Flooyr.,Flour.
+Bainney millish.,New Milk.
+Ushtey.,Water.
+"Gow oarn skihlt as broie eh ayns ushtey mysh daa oor, — eisht cur paart dy vainney millish ayn, eisht mastey red beg dy flooyr ayns bainney feayr as cur ad ayns y phash, as mastey ad gys bee ad currit lhieu gys cloie.",Take shelled barley and boil it in water about 2 hours; then add some new milk in. Mix a little flour in cold milk and put in the pot and stir until it begins to boil.
+PODDASH MEINN-CORKEY.,OATMEAL PORRIDGE.
+,"Mr. W. Cubbon, Douglas."
+Poddash meinn-corkey as bainney millish dy-liooar.,Oatmeal porridge and new milk enough.
+,
+,PORRIDGE.
+,"The Hon. J. K. Ward, Montreal."
+,1 teacupful oatmeal (middles).
+,1 pint fresh drawn cold water.
+,1 teaspoon salt.
+,"When the water is nearly boiling, slowly sprinkle in the oatmeal with the left hand, while stirring round and round with the cass-spein (the stick end of the wooden spoon) with the other hand. Add the salt and simmer for ½ an hour or longer."
+SOLLAGHAN.,SOLLAGHAN.
+(Son Anjeal Moghrey Laa-yn-Ollick.),(Served at breakfast on Christmas Day Morning)
+,
+,"Mrs. W. Cashin, Shore-road, Peel."
+Cur ghaa-ny-three dy vowlyn dy veinn corkey ayns pot-oghe dy creoiagh gys te cullyr ruy ; eisht cur y vroit er gys te mestit mie ry-cheilley. ,"Put some oatmeal in a pan on the fire and keep stirring until it is thoroughly dry and crisp, then skim the top of the broth pot on to it and stir well."
+"Cur lane spain dy eeym, as pibbyr as sollan huggey dy yannoo blastal jeh."," [Add a full spoonful of butter, and pepper and salt to flavour it.] Season with pepper and salt."
+SOLLAGHAN,SOLLAGHAN
+(Bee Shenn Vannin.),(Old Manx Recipe.)
+"S. Mylvoirrey, Purt-ny-Hinshey.","[S. Morrison, Peel]"
+“Dy yannoo mess dy hollaghan gow lane bowl ny jees dy veinn corkey. ,"To make sollaghan, take a basinful or two of oatmeal. "
+Cur y veinn ayns pot-oghe ny ayns pan er yn aile as freill chyndaa y veinn gys te creoït ayns cullyr ruy.,"Put the meal in the oven or in a pan upon the fire, and keep turning the meal until it is crisped to a reddish colour. "
+Eisht cur y veinn ayns claare ; cur sollan as pibbyr lesh cramman dy eeym ayn dy yannoo blastal jeh.,Then put the meal into a dish. Add salt and pepper with a lump of butter to flavour it. 
+"Eisht cur ghaa-ny-three dy vowlyn jeh’n anvroie ny broit harrish y veinn, as çhyndaa as mastey eh gys t’eh çhiantyn dy-cheilley ayns crammanyn.","Then put two or three basinfuls of pot-liquor or broth upon the meal, and stir and mix it until it sticks together in lumps. "
+Eisht lhig da shassoo son tammylt ; eisht lhieen soese y claare lesh y vroit gys t’eh thanney dy-liooar dy ve shirveishit magh ayns plateyn er y voayrd dy ee.,Fill up the dish with the broth until thin enough to serve out into plates upon the table to eat. 
+Ta shoh lhongey follan son deiney.”,This makes a wholesome meal for men.
+SOLLAGHAN,SOLLAGHAN.
+,"Mr. T. Moore, Brookfield, Port Erin."
+"Garvain broit ayns soolagh feill-vart, tra bee ad çhiu myr poddash cur ad ayns claare as goaill yn soolagh maroo.","Boil groats in broth, when as thick as porridge put in a dish and take the broth with them."
+SOLLAGHAN.,SOLLAGHAN.
+,(Served at breakfast on Christmas Day morning)
+,"Rev. R. D. Kermode, M.A., Maughold Vicarage."
+,Oatmeal.
+,Butter.
+,Pepper.
+,Salt.
+,Broth.
+,"Put some oatmeal in a pan upon the fire and stir until crisp and reddish. Add butter, pepper and salt. Skim the broth pot on to it and stir well until it sticks together in lumps. Serve with broth."
+BROIT SKEDDAN.,HERRING BROTH.
+,"Mr. Caesar Cashin, Peel."
+"Gow jeih skeddan oor, lesh shoushaghyn giarrit meen, lesh pibbyr as sollan dy vlastey.","10 fresh herrings, shalots or chives [chopped finely], [with] pepper and salt [to flavour]. "
+"Giare ny king as fammanyn jeu, screeb as niee ad dy ghlen.","Clean and scrape the herrings well, removing heads and tails, "
+"Cur ayns y phash ad, lesh ny shoushaghyn, lesh pibbyr as sollan, ayns mysh kaart dy ushtey feayr ","place in a pot, with the shalots finely chopped, add pepper and salt to taste, and [about] 1 quart of cold water. "
+as lhig daue cloie son mysh kerroo oor.,Bring it to the boil then simmer for 15 minutes. 
+Eisht scarr ny craueyn  voue as shirveish ad çheh ayns y broit.,"Serve the herrings in the broth, removing the bones."
+,GOOD MANX BROTH.
+,"MR. A. N. Laughton, High Baiiff of Peel."
+,"“I do not know how to make it, bit I know when it is good.”"
+,MANX BROTH.
+,"Mrs. Cain, The Esplanade, Douglas."
+,3 quarts water.
+,Scrag end of mutton.
+,A piece of beef.
+,1 breakfascup pearl barley.
+,"1 carrot, coarsely grated."
+,1 slice of turnip.
+,1 leek.
+,"Thyme, celery, chopped parsley."
+,Pepper and salt.
+,"Boil the water, add all the ingredients except the parsley, and simmer gently for 2 hours. "
+,"Ten minutes before serving, take out the meat, cut it into small pieces, returrn it to the pan, add also parsley, re-boil and serve very hot."
+,MANX BROTH FOR A WEDDING.
+,"Miss Graves, Douglas."
+,A fowl.
+,Lump of salt mutton.
+,Lump of salt pork.
+,1 big cabbage.
+,1 big turmit.
+,"2 carrots, 3 leeks."
+,Basinful of groats and barley.
+,"Parsley, thyme, chives."
+,Potatoes.
+,"Fill the three-legged pot ¾ full of water and hang it on the slowrie. Put in th emutton and pork, which should have been put in water to soak overnight, add the barley and groats, boil about an hour, then add the fowl, the turmit and carrots sliced, the cabbage, chopped fine, the thyme, chives, and about a couple of handfuls of parsley picked small. Boil an hour, adding a few potatoes about 20 minutes before taking off the fire. Serve in basins. "
+,N.B. — When well done the broth should be thick enough for the spoon to stand up in the middle of the basin. 
+CARROO FUINNIT.,BAKED CARP.
+,"Mr. W. J. Cain, Doolish."
+1 carroo,1 carp
+2 lane-spein-boayrd dy vrooillagh arran.,2 tablespoonfuls bread-crumbs.
+1 lane-spein-tey dy pharslee giarrit myn.,2 [sic] tablespoons chopped parsley.
+1 ooh veg.,1 small egg.
+1 unns dy eeym.,1 oz. butter.
+¼ pynt d’ ushtey.,¼ pynt stock or water.
+Minniag dy lossreeyn villish.,A pinch of sweet herbs.
+Pibbyr as sollan da blastyn.,Pepper and salt to taste.
+"Glen, screeb as niee yn eeast ; jean pronney marish yn chooid elley jeh ny reddyn er-lhimmey yn eeym, cur shoh ayns çheu-sthie yn eeast as puaal [sic] seose eh. ","Clean, scrape and wash the fish ; make a forcemeat with the rest of the ingredients except the butter, put this inside the fish and sew up. "
+"Cur eh ayns claare-stainney smarrit dy-mie, deayrt mygeayrt y mysh yn ushtey as cur yn eeym er y vullagh ayns meeryn veggey. ","Put in a well greased dripping tin, pour round the stock or water and place on top the butter in small pieces. "
+Lhig da fuinney mysh un oor.,Bake about 1 hour.
+BOLLAN NY HOUNEY.,HOLLANTIDE EVE SUPPER-DISH.
+,"Mrs. Daughterty, Gordon."
+Bollan sailjey.,Salt bollan.
+Ushtey feayr.,Sufficient cold water to cover the fish.
+Cur un bollan sailjey ayns ushtey feayr fud-ny-hoie ; eisht lhig da broie gys t’eh meiygh. ,"Soak the fish overnight, and boil it until tender, putting it over the fire in cold water. "
+,
+Eisht shirveish eh lesh praasyn broojit as pesmadyn. ,Serve with mashed potatoes and parsnips. 
+Ta shoh shibbyr mie er oie Houney.,This is a special supper-dish on Hollantide Eve.
+BARNEE FRYIT.,FRIED LIMPETS
+,"Mrs. Quirk, Carn-ny-Greïe."
+Kaart dy varnee.,1 qrt limpets.
+Eeym ny blennick vuickey.,Hot butter or lard.
+"Cur ny barnee ayns ushtey as sollan fud-ny-hoie; scarr ny shliggyn voue, ","Soak the “flitters” overnight in salt and water, then parboil and take off the shells. "
+cur ayns pash lesh eeym ny blennick vuickey as lhig daue broie ayns yn eeym gys hig ad gys cullyr ruy.,Clean them well and fry in hot lard until of a nice brown colour. 
+Shirveish çheh lesh arran as eeym.,Serve hot with bread and butter.
+HAAILEY DY BRICK SPOTTAGH.,PICKLED MACKEREL.
+,"Mrs. J. Nelson, Ramsey."
+"Gow kiare brick, lesh ghaa-ny-three dy unishyn giarrit thanney, cur pibbyr, as sollan, as spiceyn ny vud wheesh as nee blastal jeu. ","Cut 2 [or three] onions in thin slices, mix with salt and pepper, and a little mixed spice [as much as will flavour them] ; then have 4 mackerel ready, "
+"Lhieen builg ny brick lesh ny unishyn as spiceyn, as bee feer chiarailagh dy rubbey çheu-mooie jeh ny brick dy-mie lesh lheid cheddin.","put a little of the onions inside [the stomachs of the mackerels], [and be very careful to] rub the outside [of the mackerels well] with them [the same],"
+Eisht soillee ad dy-mie lesh flooyr as ooh.,and then rub [bind around] with flour [and egg].
+"Cur lieh pynt dy feeyn-geayr as red beg dy ushtey ayns y chlaare maroo, ","Put them in the dish, add the remainder of the onions, ½ pint vinegar, and a gill [a small amount] of water ; "
+eisht cur ayns oghe braew çheh son oor.,[then] bake in a slow [fine hot / moderate] oven [for an hour].
+Dy ve eeit feayr.,To be eaten cold.
+PRAASYN AS SKEDDAN.,POTATOES AND HERRING.
+,"The Right Rev. T. W. Drury, Bishopscourt."
+Palçhey praasyn as skeddan dy-liooar.,Plenty potatoes and herring enough.
+CLAARE DYN JISHIG.,FATHERLESS PIE.
+(Dy ve eeit lesh eeayst er Jeheiney-chaisht.),(To be eaten with boiled fish on Good Friday.)
+,"Mrs. Corkill, Circular Road, Peel."
+2 punt dy phuddasyn.,2 lbs. potatoes.
+6 unnsyn dy eeym.,6 oz. butter
+1 cappan dy vainney.,1 cupful milk.
+1 cappan dy ushtey.,1 cupful water.
+Pibbyr as sollan.,Pepper. Salt.
+Teayst dy arran-giare.,Short pastry.
+Giar ny puddasyn myn. ,"Cut the potatoes into small thin pieces, "
+Cur eeym er claare as lhieen eh eh lesh puddaseyn as eeym ny-vud. ,"butter a pie dish, fill with layers of potatoes, and pieces of butter, until all are used, "
+,adding a little pepper and salt to each layer.
+"Cur y bainney as ushtey er, coodee harrish lesh teayst dy arran-giare, as aarlee ayns oghe braew çheh.","Pour over the milk, and water, put over all an ordinary pie crust, and bake in a moderate oven."
+PRINJEIG,HAGGIS.
+(BEE BLASTAL SHENN VANNIN.),(An old Manx Savoury Dish.)
+,"Mr. J. J. Kneen, Port Erin."
+"Fow kione, aane, cree, scowanyn, as prinjeig keyrragh voish yn feilleyder eu.","Get a sheep’s head, liver, heart, and lights from your butcher. "
+Glen ad dy-mie.,Clean them well. 
+"Broie cooidjagh yn kione, aane, cree as scowanyn dys bee meigh.","Boil together the head, liver, heart, and lights until they be tender. "
+"Gow yn eill jeh’n chione, as giarrey ooilley dy-myn cooidjagh, lesh unishyn, pibbyr as sollan rere yn blastynys eu. ","Take the meat of the head, and chop all finely together with onions, pepper and salt according to taste. "
+Cur stiagh beggan lane-duirn dy veinn-chorkey garroo (S’mie lesh sleih ennagh puddaseyn giarrit feer thanney currit stiagh aynjee reesht). ,Put in a few handfuls of coarse oarmeal. (Some people like potatoes cut very thin put in it also.) 
+"Jean mastey ooilley dy-mie cooidjagh, as whaaley [sic] seose ayns y phrinjeig. ",Mix all well together and sew up in haggis. 
+Kiangle seose dy-çhionn ayns aanrit as broie son three ny kiare dy ooryn. ,Tie up tightly in a cloth and boil for 3 or 4 hours.
+Cur lesh dys y voayrd çheh lesh puddaseyn broit. ,Serve up hot with boiled potatoes.
+Freayll yn awree jeh’n chied broie son ny puddaseyn. ,Save the gravy of the first boiling for the potatoes.
+Foddee eh ve eeit lesh arran as eeym myrgeddin.,It may also be served cold with bread and butter.
+PYE MARREY NY THREE KEAYRTN THREE.,SEA PIE OR THREE TIMES THREE.
+,"Mr. and Mrs. Cashin, Douglas Road, Peel."
+"Cur ayns pash soiagh dy phraasyn aw giarrit ayns shlissagyn, ","Put into a pot a layer of raw potatoes cut into slices, "
+"jean ad blastal lesh unnishyn giarrit dy-myn, pibbyr as sollan, eisht cur soiagh dy shlissagyn dy eill; ","which season well with minced onion, pepper and salt, then put a layer of slices of meat ;"
+"jean meer dy teayst lesh eeh, mysh un oarlagh er çheeid, as runt myr yn phash ; ","make a piece of paste with suet, about 1 inch thick, and round like the pot ; "
+"cur lieh phynt dy ushtey ’sy phash, as jean coodagh yn eill lesh y teayst, ","put ½ pint of water in the pot, and cover the meat with the paste, "
+çhionney eh noi çheughyn yn phash ; cloie dy-moal son daa oor.,pressing it against the side of the pot ; simmer for 2 hours.
+Gow tastey. ,N.B.— 
+"Cordail rish yn çhenn saase lishagh ve three soiaghyn, as bee yn pye share fuinnt ayns shenn oghe phagh, as coagyrit mullagh as bun.","According to the old recipe there should be three layers, and the pie will be best baked in an old pot-oven, thus being cooked top and bottom."
+DY YANNOO BRAGHTAN DY ARRAN-OARN.,MANX SANDWICH.
+,"Mr John Nelson, Ramsey."
+"Gow berreen dy arran oarn as cur palchey eeym er, skeayl un skeddan oor skeilt as roastit er, as roll seose dy cruin ad ry-cheilley. ","Take a cake of barley bread and put plenty of butter on it, spread a fresh herring split and broiled upon it, and roll them up compactly together [one to another]. "
+Ta shoh braghtan mie dy chur ayns dty phoggad tra t’ou goll er journaa.,This is a good “Braghtan” to put in your pocket when you are going on a journey.
+BRAGHTAN DELBEE.,DALBY SANDWICH.
+,"Mr. J. Moore, Patrick."
+Gow meer dy verreen-oarn as skeayl eh lesh eeym mie. ,"Take a piece of barley cake and spread it over with fresh butter, "
+Cur cheeid dy phraasyn broojit er. ,"add a layer of potatoes bruised,"
+Eisht gow mynagyn dy skeddan sailjey as skeayl harrish. ,then a coating of salt herring nicely picked and free from bones ; 
+"Eisht cur cheeid elley dy phraasyn er, as eisht cur meer dy verreen-oarn lesh palchey eeym er harrish shen.","[Then] upon this spread another layer of potatoes, and [then] cover [put on over that] with [a piece of] barley cake and [plenty of] butter. "
+,A seasoning of pepper is an improvement.
+Lhisagh yn braghtan shoh ve eeit choud’s ta ny phraasyn çheh.,This “braghtan” should be eaten [while the potatoes are] hot.
+BINJEAN.,BINJEAN.
+,"Miss A. E. Corrin, Glenfaba."
+,"Put a quart of milk into a dish and let it warm in the oven. Then add a teaspoonful of stepe (rennet), and let it stand in a cool place until set. When cold it is ready for use. Serve in saucers, with cream and sugar."
+BINJEAN.,BINJEAN.
+,"Canon Kewley, M.A., Arbory Vicarage."
+,One pint of new milk.
+,
+,One small teaspoonful of “steep” (essence of rennet).
+,
+,"Heat the milk slightly, stir in the steep thoroughly, and place in a glass dish. When cold serve with sugar and cream. A little nutmeg, grated on the binjean when cold, is considered an improvement by some."
+GRISSNIUYS.,BIESTINGS.
+,"Mrs. Quirk, Market Street, Peel."
+Bainney.,Milk.
+Shugyr.,Sugar.
+Sollan.,Salt.
+Gow yn nah ny yn trass bainney veih yn booa lurg jee brey. ,Take the second or third milking of the cow after calving. 
+Sheeley ayns claare lesh craa beg dy hollan as shugr [sic] ny-vud dy blaystyn [sic]. ,"Strain the milk into a pudding dish, add a pinch of salt and sugar to taste. "
+Fuinney moal ayns oghe dys te çhiu.,Bake slowly in an oven until set.
+BONNAG ARRAN OARN.,BARLEY MEAL BONNAG.
+,"Miss M. Callow, Ramsey."
+¾ punt dy veein-oarn.,¾ lb. barley meal.
+¼ punt dy flooyr-veein.,¼ lb. flour.
+2 unns dy eeym ny blennick vuck.,2 oz. lard.
+Lane spain beg dy yastee-hollan.,1 small teaspoonful soda.
+Lane spain beg dy tartar.,1 small teaspoonful cream-of-tartar.
+Bainney-geayr as sollan.,Salt. Buttermilk.
+Jean mastey dy-cheilley gys teayst. ,"[Mix together until dough]. Mix the barley meal, soda, cream-of-tartar, and salt well together in a bowl. Rub in the lard until as fine as oatmeal, then add sufficient buttermilk to make into a moderately soft dough. "
+,
+"Jean bonnagyn jeu, as aarlee ayns oghe braew çheh son mysh oor. ",[Make them into bonnags and cook in a moderately hot oven for about an hour.] Form into 2 or 3 round or oblong shaped loaves. Bake in a moderately hot oven about an hour. 
+Ta bonnagyn flooyr jeant er yn aght cheddin.,Flour bonnags are made in the same way by omitting the barley meal and adding the same weight of flour to the other ingredients.
+ARRAN JINSHAR.,GINGERBREAD.
+,"Mr. W. J. Cain, Dooilish."
+1 punt dy flooyr.,1 lb. flour.
+3 unnsyn dy smarrey muck.,"3 oz. suet, dripping or lard."
+4 unnsyn dy shugyr dhone.,4 oz. brown sugar.
+1 naggin dy vainney millish.,1 gill milk.
+½ phunt dy soolagh-shugyr.,½ lb. syrup.
+2 lane-spein-tey fy jinshar beihllt.,2 teaspoonfuls ground ginger.
+1 lane-spein-tey dy yastee hollan.,1 teaspoonful carbonate soda.
+1 lane-spein-tey dy phoodyr fuinney.,1 teaspoonful baking powder.
+1 lane-spein-tey dy rass-carvay (myr silliu [sic]).,1 teaspoonful carraway seed (if liked).
+1 ny 2 dy oohyn.,1 or 2 eggs.
+Sollan.,Salt.
+"Jean mastey cooidjagh ny stoohyn çhirrym, lheie yn smarrey as yn soolagh-shugyr ayns pash. ","Mix the dry ingredients together, melt the dripping and syrup in a pan. "
+"Jean mastey yn ooh dy-mie, as jean mastey ad ooilley cooidjagh. ",Beat the egg well. Mix all well together. 
+Deayrt ad ooilley ayns claare-stainney mooar. ,Pour the mixture into a lage dripping pan. 
+Lhig daue ve fuinnt ayns oghe lane-vie çheh son mysh oor.,Bake in a moderate oven nearly one hour.
+BERREENYN INNYD.,MANX PANCAKES.
+,"Mrs. R. Shimmin, Peel."
+Pynt dy flooyr.,1 pt. flour.
+Kaart dy vainney-geayr.,1 qrt. Buttermilk.
+Lane spein beg dy hollan.,1 small teaspoonful carbomate of soda.
+Lane spein beg dy yastee-hollan.,1 small teaspoonful salt.
+Jean shiu mastey dy-cheilley gys t’ad ooilley jeant meein. ,"[Mix together until they are all fine / smooth / free from lumps] Stir the buttermilk very gradually into the other ingredients, making a smooth batter free from lumps, until the quart is all stirred in. "
+,
+"Eisht cur lane cappan er y phan son dagh berreen, aarlee gys t’ad cullyr ruy. ","[Then put a full cup on the pan for each cake, cook until they are a reddish-brown colour] Pour a teacupful of the batter into a well greased, heated frying pan. Fry over a moderately hot fire. When lightly browned on each side, take off and pile one over the other on a warm plate."
+"Cur eeym eddyr oc, as lhig daue shassoo son tammylt beg. ","[Put butter between them, and let them stand for a little while]. Rub a little butter over each cake as it is put on the plate."
+Ee choud’s çheh. ,[Eat while hot].
+Lhisagh yn towse shoh dy veein jannoo mysh jeih berreenyn as hoght.,This recipe should make one and a half dozen cakes.
+BERREEN GIAR VANNINAGH.,MANX SHORT CAKE.
+,"Mrs. Clague, Crofton, Castletown."
+     Nee shiu goaill punt dy vein corkey veen.,     Take a pound of fine oat meal.
+Kerroo punt dy eeym.,Quarter of a pound of butter.
+Kerroo punt dy smarrey muck.,Quarter of a pound of lard.
+Lieh punt dy hugyr.,Half a pound of sugar.
+Un lane spain boayrd dy phoodyr son fuinney as red beg dy hollan.,A teaspoonful of baking powder and a little salt.
+     Jean shiu yn eeym as smarrey bog. ,"     Mix the butter and lard soft, "
+Agh ny jean shiu lheie ad. ,but do not melt them. 
+Mastey shiu ad lesh yn vein corkey. ,"Mix them with the oat meal, "
+As jean teayst jeu marish red beg dy chesh shugr [sic] as jean berreenyn jeu. ,"[and make them into dough and knead with a little treacle, and roll into cakes, "
+Cur shiu y teayst ayns claareyn stainney slaait lesh eeym. ,Put the dough in the dishes rubbed [smeared] with butter. 
+Cur shiu ayns oghe çheh. ,Place in a hot oven.
+Tra t’ad fuinnt giare shiu ad ayns meeryn keare [sic] corneilagh.,When they are baked cut into squares.
+MIE SON SLEIH ASLAYNTAGH,GOOD FOR PEOPLE OUT OF HEALTH.
+,"Dr. Clague, Castletown."
+Chiow shiu pint dy vainney red beg.,Warm slightly a pint of milk.
+Bleckey shiu ooh ayns cappan.,Whisk an egg in a cup.
+Mastey shiu ad coodjagh.,Mix them together.
+Cur shiu ayn lane spain boayrd dy soolagh binnid.,Put a small spoonful of essence of rennet.
+Cur ad dy lhiattee dy yannoo binjean.,Place aside to make curd.
+Foddee shiu goaill eaghtyr ooillagh as shugyr marish.,You may take cream and sugar with it.
+Nee shiu goaill pint dy vainney.,"Take a pint of milk,"
+Nee shiu bleckey daa ooh.,Whisk two eggs.
+Nee shiu mastey ny oohyn as y bainney coodjagh.,Mix the eggs and milk together.
+"Cur shiu ayn red beg dy hollan, shugyr as spiceyn.","Put a little salt, suger and spice."
+Nee shiu fuinney ayns oghe nagh vel ro heh.,Bake in an oven that is not too warm.
+BERREENYN KEYL.,SLIM CAKES
+,"Mrs. Kee, Peel."
+1 punt dy flooyr.,1 lb. flour.
+½ spein-tey dy yastee-hollan.,½ teaspoonful carbonate of soda.
+Bhittag vea.,Rich sour cream.
+2 lane spein-sollan dy hollan.,2 saltspoonfuls salt.
+"Gow shiu yn flooyr, jastee-hollan, as sollan, as jean mastey ad coodjagh. ","[Take the flour, bicarbonate of soda, and salt, and mix them together] Sift together the flour, soda, and salt ; work this all well together moistening it first"
+Cur dy-liooar bhittag ayn dy yannoo teayst bog as jean gobbragh ad dy-mie coodjagh. ,[Put enough sour cream in it to make a oft dough and work it well together] with sufficient cream to form a soft dough. 
+"Tra ta shoh meeley, çhyndaa eh er boayrd flooyrit dy-mie, as rowl ad magh ayns berreenyn thanney, eisht jean fuinney ad er gryle.","When this is smooth, turn it on to a well-floured board, and roll [them out] into thin cakes, then bake on a girdle."
+BERREENYN JASTEE-HOLLAN.,SODA CAKES.
+,"Mrs. Enos Christian, Ballacraine."
+3 puint dy flooyr.,3 lbs. flour.
+¼ puint dy vlennick-vuc.,¼ lb. lard.
+1 lane spein-tey mie dy hollan.,1 heaped teaspoonful salt.
+,1 small teaspoonful carbonate soda.
+Bainney-geayr.,Buttermilk.
+"Jean mastey ad ooilley dy-mie cooidjagh, cur dy-moal huggey yn bainney-geayr (nee bainney millish t’er hyndaa geayr jannoo chammah) derrey ta’n teayst bog dy-liooar son rowlah [sic] magh. ",Mix all well together and stir in gradually some [the] buttermilk (new milk that has turned sour will do either [as well]) until the dough is soft enough for rolling out.
+Ny jean eh ro vog ny nee eh lhiantyn gys y maidjey fuinney. ,Do not make it too soft or it will stick to the rolling pin. 
+"Rowl magh yn teayst gys mysh çheeid lieh oarlagh, as jean giarrey eh gys cummey runt myr ta shiu laccal eh.","Roll out the dough to about a thickness of ¼ inch, and trim to a round shape the size required."
+Jean fuinney eh er gryle ny phash harrish aile meeley. ,Bake on a griddle or pan over a not too hasty fire. 
+Tra t’eh er nirree as red beg dhone çhyndaa yn berreen as lhig da’n çheu elley geddyn red beg dhone.,When it has risen and is slightly brown turn the cake and let the other side brown lightly.
+SODDAG VALLOO ,(DUMB CAKE).
+,(MADE on old Hollantide Eve.)
+,"Mr William Cashin, Peel Castle."
+,A remnant of that ancient mythology— “and the made cakes to the Queen of Heaven.” The new moon being considered the goddess of matrimony.
+,"The cake must be made of flour and water without any leaven, and in silence, and baked in the hot turf ashes. A piece must be eaten walking backwards to bed. A number may join in the performance and they are supposed to dream of their future husbands."
+FEEYN BERRISH-TRAMMAN.,ELDER-BERRY WINE.
+,"Mrs. J. J. Kneen, Port Erin."
+4 kaartyn dy verrishyn-tramman mea.,1 gallon ripe elderberries.
+2 lane cappan brishey-hrostee dy raisinyn.,2 breakfastcups raisins.
+6 kaartyn dy ushtey broie.,6 quarts boiling water.
+2 veer dy yinshar slane.,2 pieces whole ginger.
+Gys dagh 4 kaartyn sy soolagh cur huggey 6 lane cappan brishey-hrostee dy shugyr crammanagh.,To each gallon of juice allow 6 breakfast-cupfuls loaf sugar.
+3 cloveyn.,3 cloves.
+Shlissag dy arran-ghreddan.,A slice of toast.
+4 ooilley-spiosyn.,4 allspice.
+1 dus. almonyn millish.,1 doz. sweet almonds.
+,½ oz. yeast.
+Gow ny stilk jeh ny berrishyn as niee ad. ,Strip the berries from the stalks and wash them. 
+"Cur ad ayns phash-craie mooar, deayrt yn ushtey broie orroo, jean coodagh dy-çhionn as jean gaagail ad 24 ooryn [sic].","Put them in a large earthenware jar, pour the boiling water on them, cover tightly, and leave for 24 hours."
+"Sheel yn soologh [sic] trooid shollane geaysh, broo as traastey dy-mie ny berrishyn. ","Strain juice through a hair sieve, braising and pressing the berries well. "
+Jean towse yn soolagh ayns phash craie.,Measure the juice into an earthenware pan or a preserving pan. 
+Cur huggey ny reddyn elley.,Add the required quantity of the ingredients. 
+Cloie son un oor. ,Boil for 1 hour. 
+Gow mennick yn kesh jeh. ,"Keep it well skimmed,"
+Lhig da feayragh. ,Let it cool. 
+Tra blaa-hiass jean deayrtey eh ayns mullag ny costraylyn. ,When luke warm pour into a cask or jars. 
+Slaa jastee er yn arran-greddan as cur hug yn feeyn. ,Spread yeast on the toast and add to the wine. 
+Jean coodagh y vullag as lhig da sooragh son kiare laghyn jeig. ,Cover the cask and let it ferment 14 days. 
+"Tra t’eh er scuirr, cur eh ayns yn vullag fakin dy vel y dhull çhionn, as jean stoyral ayns boayl feayr çhirrym. ","When it has stopped, cork it down tightly and store in a cool dry place. "
+Cur eh ayns boteilyn mysh yn Ollick.,Bottle it about Xmas.
+FEEYN SMEYR-GHOO.,BLACKBERRY WINE.
+,"Mr. and Mrs. T. Quane, Peel."
+5 kaartyn dy smeir-ghoo.,5 qrts. blackberries.
+5 kaartyn dy ushtey feayr.,5 qrts. cold water.
+Shugyr Demerara.,Demerara sugar.
+Cur yn mess as yn ushtey ayns crockan. ,Put the fruit and water into a crock.
+"Lhig da shassoo son 3 ny 4 dy laghyn, mastey yn mess dy chooilley laa ; eisht cloie ad nyneesht cooidjagh son jeih minnidyn. ","Let this stand 3 or 4 days, stirring the fruit every day : then boil together for 10 minutes. "
+,
+"Lurg shen, cur yn soolagh trooid shollane, as tra dy bee eh blaa-hiass, cur gys dy-chooilley kaart jeh’n soolagh, un phunt dy shugyr Demerara. ","After this, strain off the liquor, and when lukewarm, add  to every quart of the liquor, 1 lb. Demerara sugar. "
+"Lhig da’n soolagh lheïe ersooyl, as tra bee eh feayr cur eh ayns boteilyn. ","Let the sugar dissolve, and when cold bottle. "
+Lurg jeih laa cur cur dys dagh boteil lane spein-boayrd dy vrandy.,After 10 days add to each bottle 1 tablespoon of brandy.
+LHUNE LOSSEREY.,HERB BEER.
+(Shenn Saase Manninagh.),(Old Manx Recipe.)
+,"Miss L. Shimmin, Peel."
+"Gow lane-doarn dy luss ny minniag, y lheid cheddin dy undaagagh, airh-hallooin, carrageyn-keoie, luss y çhiolg, keym-Chreest, bossan feeackle, luss ny moal moirrey, vervain, edyr nep ny ob, as jean cloie son lieh oor as sheel trooid shollane.","Take 1 handful each of dandelions, nettles, yarrow, wild carrot, St. John’s wort, centaury, violet, marsh mallows, vervine, either horehound or hops, and boil for ½ hour and strain."
+Gys hoght kaartyn dy soolagh cur edyr un phunt dy soolagh-shugyr ny lieh phunt dy shugyr aw as lhig da shassoo ayns boayl çheh gys blaa-hiass.,"To 2 gallons of liquid add either 1 lb. treacle or ½ lb. raw sugar, and let it stand in a warm place until lukewarm."
+Eisht cur huggey daa unns dy yastee as jean coodagh.,Then add 2 oz. of yeast and cover.
+"Lhig da sooragh dy-mie, eisht gow shiu yn kesh jeh as cur ayns boteilyn.","Let it work well, then skim it and bottle."
+,
+KEIRN LIGGAR.,MOUNTAIN ASH LIQUEUR.
+,"Mrs. Kneen, Michael."
+,1 pint brandy.
+,1 pint syrup.
+"Teiy lane dhoarn dy verrishyn unjin cliue [sic],",[Pick] 1 handful picked keirn berries.
+chirmey ad gys t’ad shirgit. ,"The berries must be dried till shrivelled, "
+"Eisht cur ny berrishyn ayns pynt dy liggar son mysh jeih laa, broo as sheeil ad. ","then placed in [a pint of] brandy [liquor] and left from a week to 10 days. Then [press / squash and] strain, "
+Eisht cur mysh yn un towse dy syrup jeant dy shugyr bane.,"and mix with an equal quantity of thick, very clear syrup, made with loaf sugar."
+DY REAYLL SMEIR-GHOO AS OOYLYN.,BLACKBERRY AND APPLE JAM.
+,"E. A. C., Peel."
+Gow kiare punt dy smeir-ghoo.,4 lbs. blackberries.
+Shey ooylyn geayr (Paddy Kraayllyn ny ooylyn share).,6 sharp apples (the Paddy Kneale’s are the best).
+Nuy cappanyn dy shugyr bane.,9 breakfastcupfuls loaf sugar.
+Un cappan dy ushtey.,1 teacupful water.
+Broie ny ooylyn as sugyr [sic] ayns yn ushtey gys t’ad meiygh.,"Cook apples, sugar and water till the apples are tender, "
+Eisht cur ny smeir huc as broie er aile dree gys t’ad aarlit. ,add blackberries. Boil steadly till the jam sets [they are are cooked]. 
+"Lhig daue feayraghey son tammylt beg, eisht cur ayns siyn çhirrym çheh. ","[Let them cool down for a while, then put into warm, dry vessels] When cool pour into dry heated jars, "
+"Lhig daue shassoo gys laa-ny-vairagh, eisht ","[Let them stand until the next day, then]"
+coodee lesh pabyr kiarit er ny hon as freayllee ayns boayl çhirrym.,cover with paper [prepared for it] and keep it in a dry place.
+GLEIG MILLISH KEIRN,MOUNTAIN ASH JELLY.
+,"Miss E. C. Craine, Sulby."
+Berrishyn mea keirn.,Ripe keirn berries.
+2 lane cappanyn brishey hrostee jeh shugyr crammanagh gys dagh pynt jeh’n soolagh.,2 breakfastcupfuls of loaf sugar to each pint of juice.
+"Gow ny stilk jeh ny berrishyn, niee ad as sheel yn ushtey jeu. ","Stalk the berries, wash and drain [the water off] them. "
+Cur ad ayns phash freayltagh lesh dy-liooar ushtey feayr daue dy floaddal ayn.,Put them into a preserving pan with enough cold water [for them to float in] to well float them. 
+"Lhig daue cloie dy-moal er yn aile mysh daaeed minnid, ny gys bee yn ushtey jiarg as ny berrishyn goaill toshiaght dy vrishey.","[Let them] Simmer [on the fire] about 40 minutes, or until the water is red and the berries are beginning to break."
+"Lhig da’n soolagh v’eh currit trooid shollane, agh ny jean traastey yn mess.","[Let the juice be put through a sieve] Strain off the juice, but do not press the fruit. "
+"Jean shiu towse eh reesht ayns yn phash as cur yn shugyr huggey ; cloie eh dy-tappee derrey nee paart jeh soiaghey dy-tappee, eisht cur eh er claare.","Measure it back into the pan, add the sugar. Boil jelly [it] quickly until some of it sets quickly when [then] put on a plate. "
+Jean shiu goaill yn kesh jeh as cur eh ayns siyn craie.,Skim well and pot.
+,OLD MANX DISH.
+,"Miss C. E. Goodwin, Peel."
+“Pott mie dy vainney broie,A good pot of boiling milk
+"Lesh crie braew dy veinn er,","With a brave shake of meal on it,"
+Lesh berreen dy arran oarn,With a cake of barley bread
+Lesh çheeid dty vass dy eeym er.”,With the thicknes of your hand’s palm of butter on it.
+LUSS-NY-GREG SAILLT,PICKLED SAMPHIRE.
+,"Miss A. Keegan, Peel."
+"Cur luss-greg ayns crockan as coodee lesh saailley, jean shiu mastey eh son shey dy laghyn, eisht sheel yn ushtey jeh as cur eh ayns ushtey oor son kiare ooryn as feed.","Put samphire in a crock and cover with brine, stir every day for six days, then drain it and put in fresh water for 24 hours, "
+,
+Eisht gow magh eh as jean çhirmagh lesh coodagh er.,"then take it out and dry with a cloth, and put it in. a jar with cover. "
+"Cloie feeyn-geayr lesh cayenne, pibbyr, jinshar, mase, cloveyn as kuse veg dy ghuillagyn millish.","Boil vinegar with cayenne, pepper, ginger, mace, cloves, and a few bay-leaves, "
+Deayrt feeyn-geayr broie er luss-ny-greg.,pour boiling vinegar over samphire.
+"Jean shiu shoh son kiare dy laghyn, coodagh dy-çhionn yn costrayl dagh keayrt as cummal eh faggys da’n aile.","Repeat this for four days, covering jar closely each time, and keep near the fire. "
+Cur ayns boteilyn tra feayr.,Bottle when cold. 
+Nee meer veg dy ollym currit ayns y chostrayl jannoo ny share yn daah.,A small bit of alum put in the jar will improve the colour.
+Freayl eh ayns boteilyn voish yn aer.,Keep in air-tight bottles.
+PUIDDIN OOH,BATTER PUDDING.
+,"Mrs. Camaish, Peel."
+2 ooh.,2 eggs.
+Pynt dy vainney millish.,Pint of milk.
+2 cappan dy flooyr.,2 cupfuls four.
+Red beg dy hollan.,A little salt.
+"Mastey ad dy-cheilley gys t’ad ooilley fud-y-cheilley, as gyn crammanyn ; eisht kiangle eh seose ayns aanrit, faastit ass ushtey çheh, as spreihy lesh flooyr. Cloie son oor, as ee lesh aunlyn millish.","Make the batter with the above ingredients ; when quite smooth, tie the mixture up in a pudding cloth wrung out in warm water and floured, boil for an hour, and serve with sweet sauce."
+Aunlyn millish. ,Sweet sauce.
+"Thanney daa lane spain lesh daa naggin dy vainney millish, cur da uns eeym as miljey eh lesh shugyr. ","Thin 2 tablespoonfuls of the batter with ½ pt. milk, add 1 oz. butter and sweeten with sugar."
+Lhig da cloie un minnid.,Stir and boil 1 minute.

--- a/OpenData/secular printed material - 1900 - 1921/Manx Dishes/license.txt
+++ b/OpenData/secular printed material - 1900 - 1921/Manx Dishes/license.txt
@@ -1,0 +1,11 @@
+## Original Manx
+
+This work was published before January 1, 1926, and is in the public domain worldwide because the author died at least 100 years ago.
+
+## English
+
+Rob Teare 2024
+
+## Transcription
+
+Rob Teare 2024

--- a/OpenData/secular printed material - 1900 - 1921/Manx Dishes/manifest.json.txt
+++ b/OpenData/secular printed material - 1900 - 1921/Manx Dishes/manifest.json.txt
@@ -1,0 +1,22 @@
+{
+	"created": "1908-08-27",
+	"ident": "Manx-Dishes",
+	"name": "Manx Dishes",
+	"englishName": "Manx Dishes",
+	"notes": "'Manx Dishes' is a chapter (pages 172 to 203) in 'The Manx Cookery Book'. The full front title of the book is 'THE MANX COOKERY BOOK — ISSUED IN AID OF THE PEEL CHURCH SPIRE REBUILDING FUND'. On the inside cover page it is titled 'THE MANX COOKERY BOOK Of FAVOURITE DISHES'. It was published by Sherratt & Hughes of London & Manchester in 1908. Most of the recipes are given in Manx, with English beneath. The preface finishes with 'Sophia Morrison and Louisa Morrison, Lady Raglan's Stall, Church Spire Rebuilding Fund Bazaar, Christian's Schools, Peel. August 26th and 27th, 1908.' The book was available for sale at the bazaar, so was evidently published before that date. 
+
+Contributors to the 'Manx Dishes chapter include many who were also involved with the Manx Society (YÇG). The contributions appear not to have been edited or standardised. 
+
+The use of the imperative and choice of formal (plural) / informal (singular) forms varies considerably. 
+
+Where details that appear in the Manx versions of the recipe are omitted or differ to the English translation a translation (by R. Teare) has been inserted in square brackets. The Manx has not been altered, except in a few instances where an evident typo of [c] for [l] has been corrected, eg; [lhiabbee] for [chiabbee]. 
+
+Mr. Thomas Crellin, Oakland, California is credited in the preface with having paid the costs of publication. The two day bazaar itself included performances of Cushag's plays; 'Rosie Basins' and 'The Lazy Wife, also offered collections of Manx prints and paintings and had stalls representing Ireland, Scotland, the Isle of Man, England, Wales, Japan and Norway. It was reported to have raised £600 towards the fund.",
+	"author": "various",
+	"editor": "Morrison. S & Morrison. L.",
+	"original": "Manx",
+	"type": "culinary",
+	"transcription": "R. Teare",
+	"source":  "'Manx Dishes' in THE MANX COOKERY BOOK — ISSUED IN AID OF THE PEEL CHURCH SPIRE REBUILDING FUND. Sherratt & Hughes, Manchester & London, 1908. Pages: 172-203",
+	"englishSource": "'Manx Dishes' in THE MANX COOKERY BOOK — ISSUED IN AID OF THE PEEL CHURCH SPIRE REBUILDING FUND. Sherratt & Hughes, Manchester & London, 1908. Pages: 172-203, with some additions in square brackets by R. Teare (2024)",
+}


### PR DESCRIPTION
A Chapter in 'The Manx Cookery Book' 1908. (p172-203). Most are in Manx first, with English translation. A few in English only.