### PR TITLE
add: Ned Beg - Juan Hom Drummey

### DIFF
--- a/OpenData/NedBeg/Juan Hom Drummey/document.csv
+++ b/OpenData/NedBeg/Juan Hom Drummey/document.csv
@@ -1,0 +1,22 @@
+﻿Manx,English,Notes
+Va shenn eeasteyr cummal ayns Fistart.,There was an old fisherman living in Fistard. ,
+Veagh eh fuirraght sthie ooilley yn geurey as cheet magh tra veagh yn earish aalin ayns yn tourey.,He would stay home all winter and come out when the weather was fine in the summer.,
+Veagh yn sleih gyllagh Cook Cook da son dy row eh gollrish yn chooag; as veagh eh feer fargagh.,The people called him Cook-Cook because he was like the cuckoo; and he would be very angry.,
+V’eh feer vie dy insh skeealyn beggey v’er haghyrt ayns y vea echey hene.,He was very good at telling little stories about what had happened in his own lifetime.,
+Veagh eh dy mennick ginsh dooin mychione Juan Hom Drummey. ,He would often tell us about Juan Hom Drummey.,
+"Cha vel fys aym cre va’n sliennoo echey, agh v’eh jeeaghyn dy row eh feer litcheragh as ny chadlag.","I do not know what his surname was, but it seems he was very lazy and a sluggard.",
+"     Veagh Moore gra dy ren ad faagail Purt le Moirrey un cheayrt dy gholl gys yn eeastagh scaddan, as ren Juan Hom Drummey goll dy lhie, son veagh eh dy mennick ny chadley tra veagh obbyr dy yannoo.","     Moore would say that they left Port St. Mary one time to go to the herring fishing, and Juan Hom Drummey went to bed, for he would often be asleep when there would be work to do.",
+Ren ad shiaulley er yn laa shoh gys v’ad er Geaylin yn Cholloo. [1],They sailed this day till they were on Geayllyn yn Cholloo.,[1] Geaylin yn Cholloo - ‘headland on the Calf of Man’ Broderick (1982b: 132).
+Agh va Juan Hom Drummey ny chadley foast.,But Juan Hom Drummey was still asleep.,
+Tra v’eh er-gerrey da croymmey ny greiney va Juan ny chadley foast. ,When it was near to sunset Juan was still asleep.,
+Honnick ad yn pherkin vooar agh va Juan ny chadley foast.,They saw the big porpoise but Juan was still asleep.,
+Ren ad cur yn lieen. ,They cast the net. ,
+Va Juan foast ny chadley. ,Juan was still asleep.,
+"Ec yn vean-oie ren ad prowal yn lieen, as va warpyn [2] mie dy scaddan ayn, agh va Juan Hom Drummey ny chadley foast. ","At midnight they proved the net, and there were good warps of herring, but Juan Horn Drummey was still asleep.","[2] ‘a warp is three herring; in a long hundred there were forty warps, plus another for luck, plus an additional herring called the Talley, which made a total of 124 fish.’ Broderick (1982b: 132). The OED’s definition (warp n.1 III.5.a.) is ‘a tale of four (occas. three or a couple), esp. used of fish and oysters.’ It cites Hall Caine’s Manxman (1894), ‘Every man ate his warp of herring’."
+Moghrey tra ren yn laa brishey ren ad tayrn yn lieen er boayrd agh va Juan ny chadley foast.,"In the morning when day broke they hauled the net on board, but Juan was still asleep.",
+Ren ad troggal yn shiaull as jannoo son yn vaie.,They raised the sail and made for the bay.,
+Va Juan ny chadley foast.,Juan was still asleep. ,
+"Ren ad craa yn scaddan ass yn lieen er yn raad gys y vaie, agh va Juan ny chadley foast.","They shook the herring out of the net on the way to the bay, but Juan was still asleep.",
+Tra ren ad roshtyn yn vaie va Juan ny chadley foast.,When they reached the bay Juan was still asleep. ,
+"Haink ad gys lhiattee kionneyder, agh va Juan foast ny chadley.","They came alongside a buyer, but Juan was still asleep. ",
+"Agh tra va’n boteil currit lesh er boayrd, va Juan Hom Drummey dooisht as yn chied dooinney ny chione.","But when the bottle was brought on board, Juan Hom Drummey was awake and the first man in the queue.",

--- a/OpenData/NedBeg/Juan Hom Drummey/license.txt
+++ b/OpenData/NedBeg/Juan Hom Drummey/license.txt
@@ -1,0 +1,14 @@
+## Original Manx
+
+This work was published before January 1, 1926, and is in the public domain worldwide because the author died at least 100 years ago.
+
+## Corrected Manx
+
+Broderick (1981), Lewin (2014) text 5.
+
+Edition and translation by Christopher Lewin.
+
+## English
+
+Edition and translation by Christopher Lewin (2025)
+

--- a/OpenData/NedBeg/Juan Hom Drummey/manifest.json.txt
+++ b/OpenData/NedBeg/Juan Hom Drummey/manifest.json.txt
@@ -1,0 +1,12 @@
+{
+  "createdCircaStart": "1899-01-01",
+  "createdCircaEnd": "1899-12-31",
+  "ident": "NedBeg-Juan-Hom-Drummey",
+  "name": "Juan Hom Drummey",
+  "original": "Manx",
+  "notes": "References:\n\nBroderick, George. 1981. \u2018Manx stories and reminiscences of Ned Beg Hom Ruy (introduction and texts)\u2019. Zeitschrift f\u00FCr celtische Philologie 38: 113-178. \nBroderick, George. 1982. \u2018Manx stories and reminiscences of Ned Beg Hom Ruy (translation and notes)\u2019. Zeitschrift f\u00FCr celtische Philologie 39: 117-194.\nLewin, Christopher. 2014. Lioar-lhaih Ghaelgagh. Original Manx Gaelic Prose 1821-1907. Douglas: Culture Vannin.\nOED. Oxford English Dictionary.",
+  "author": "Edward Faragher",
+  "digitisation": "Broderick (1981), Lewin (2014) text 5",
+  "translation": "Christoper Lewin",
+  "source": "MNHL MS 00431C"
+}


### PR DESCRIPTION
With thanks to Dr. Christopher Lewin

----

MNHL MS 00431C, Edward Faragher (Ned Beg Hom Ruy), 1831–1908.

Broderick (1981), Lewin (2014) text 5.

Edition and translation by Christopher Lewin.

References:

- Broderick, George. 1981. ‘Manx stories and reminiscences of Ned Beg Hom Ruy (introduction and texts)’. Zeitschrift für celtische Philologie 38: 113-178. 
-  Broderick, George. 1982. ‘Manx stories and reminiscences of Ned Beg Hom Ruy (translation and notes)’. Zeitschrift für celtische Philologie 39: 117-194. 
- Lewin, Christopher. 2014. Lioar-lhaih Ghaelgagh. Original Manx Gaelic Prose 1821-1907. Douglas: Culture Vannin. 
- OED. Oxford English Dictionary.