### PR TITLE
feat: consider Brooillagh to be a collection of dated lines

### DIFF
--- a/DocumentTests.cs
+++ b/DocumentTests.cs
@@ -76,6 +76,9 @@ namespace Manx_Search_Data
         [Theory]
         public void DefinitionHasDate(Document definition)
         {
+            // a fragments collection (NotesCitationTests) dates from its lines' citations
+            Assume.That(!definition.NotesCitations, "dated per line by its notes' citations");
+
             Assert.That(definition.CreatedCircaStart, Is.Not.Null, $"Either '{nameof(Document.Created)}' or '{nameof(Document.CreatedCircaStart)}' must be set");
             Assert.That(definition.CreatedCircaEnd, Is.Not.Null, $"Either '{nameof(Document.Created)}' or '{nameof(Document.CreatedCircaEnd)}' must be set");
         }
@@ -83,6 +86,8 @@ namespace Manx_Search_Data
         [Theory]
         public void DefinitionDatesAreValid(Document definition)
         {
+            Assume.That(!definition.NotesCitations, "dated per line by its notes' citations");
+
             Assert.That(definition.CreatedCircaStart, Is.LessThanOrEqualTo(definition.CreatedCircaEnd), $"'{nameof(Document.CreatedCircaStart)}' was greater than '{nameof(Document.CreatedCircaEnd)}'");
         }
 

--- a/NotesCitationTests.cs
+++ b/NotesCitationTests.cs
@@ -1,0 +1,96 @@
+using Manx_Search_Data.TestData;
+using Manx_Search_Data.TestUtil;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Manx_Search_Data
+{
+    /// <summary>
+    /// The fragments-collection contract (Brooillagh): a manifest declaring
+    /// "notesCitations" is one CSV of lines gleaned from many sources, each line
+    /// dated by the citation in its Notes cell, lines without one belonging to the
+    /// last cited fragment. These tests keep every line datable - a citation the
+    /// parser cannot read would silently date its fragment to the previous one.
+    /// </summary>
+    [TestFixture]
+    public class NotesCitationTests
+    {
+        [DatapointSource]
+        // ReSharper disable once UnusedMember.Global
+        public Document[] AllDocuments = Documents.AllDocuments.ToArray();
+
+        [Theory]
+        public void CitationsAreReadable(Document document)
+        {
+            Assume.That(document.NotesCitations, "not a fragments collection");
+
+            var unreadable = document.LoadLocalFile()
+                .Select((line, index) => (line.Notes, Row: index + 2))
+                .Where(x => NotesCitationDates.LooksDatedButUnparsed(x.Notes))
+                .ToList();
+
+            Assert.That(unreadable, Is.Empty,
+                "These notes look dated but their citation cannot be read - the line would " +
+                "silently take the previous fragment's date:\n" +
+                string.Join("\n", unreadable.Select(x => $"  row {x.Row}: {x.Notes}")));
+        }
+
+        /// <summary>The document's lines dated as production dates them. A scratch
+        /// document takes the derived range: the shared datapoint must stay as its
+        /// manifest loaded it (<see cref="TheManifestOmitsCreated"/>).</summary>
+        private static System.Collections.Generic.List<DocumentLine> PreparedLines(Document document)
+        {
+            var lines = document.LoadLocalFile();
+            DocumentLinePreparer.Prepare(new OpenSourceDocument { NotesCitations = true }, lines);
+            return lines;
+        }
+
+        [Theory]
+        public void EveryLineIsDated(Document document)
+        {
+            Assume.That(document.NotesCitations, "not a fragments collection");
+
+            var lines = PreparedLines(document);
+
+            var undated = lines
+                .Select((line, index) => (line.Date, Row: index + 2))
+                .Where(x => x.Date == null)
+                .ToList();
+
+            Assert.That(undated, Is.Empty,
+                "Lines before the first citation cannot be dated - give the first fragment " +
+                $"a cited note. Undated rows: {string.Join(", ", undated.Select(x => x.Row))}");
+        }
+
+        [Theory]
+        public void DatesArePlausible(Document document)
+        {
+            Assume.That(document.NotesCitations, "not a fragments collection");
+
+            var lines = PreparedLines(document);
+
+            var implausible = lines
+                .Select((line, index) => (line.Date, line.Notes, Row: index + 2))
+                .Where(x => x.Date != null
+                            && (x.Date.Value.Year < 1500 || x.Date.Value.Year > DateTime.Now.Year))
+                .ToList();
+
+            Assert.That(implausible, Is.Empty,
+                "A fragment cannot predate Manx print or postdate its transcription:\n" +
+                string.Join("\n", implausible.Select(x => $"  row {x.Row}: {x.Notes}")));
+        }
+
+        /// <summary>The collection's date range is the span of its lines: a manifest
+        /// "created" would be the transcription's date, not the fragments', and is
+        /// overridden at load - delete it rather than leave it lying</summary>
+        [Theory]
+        public void TheManifestOmitsCreated(Document document)
+        {
+            Assume.That(document.NotesCitations, "not a fragments collection");
+
+            Assert.That(document.CreatedCircaStart, Is.Null,
+                "'created' should not be set: the lines' citations date the collection");
+        }
+    }
+}

--- a/OpenData/Brooillagh 2/manifest.json.txt
+++ b/OpenData/Brooillagh 2/manifest.json.txt
@@ -1,5 +1,5 @@
 {
-  "created": "2026-07-14",
+  "notesCitations": true,
   "ident": "Brooillagh",
   "name": "Brooillagh - Manx words and phrases within English text",
   "English name": "Brooillagh - Manx words and phrases within English text",

--- a/TestUtil/Document.cs
+++ b/TestUtil/Document.cs
@@ -50,6 +50,15 @@ namespace Manx_Search_Data.TestUtil
         /// </summary>
         public List<string> InlineSpeakerCodes { get; set; }
 
+        /// <summary>
+        /// The collection is fragments from many sources (Brooillagh), each line's
+        /// Notes cell citing its real source and date ("[M.H., 05/05/1858]"). Lines
+        /// date from their citations at load time - a line without one belongs to the
+        /// last cited fragment - and the collection's own date range becomes the span
+        /// of its lines. See <see cref="NotesCitationDates"/>.
+        /// </summary>
+        public bool NotesCitations { get; set; }
+
         internal abstract List<DocumentLine> LoadLocalFile();
         internal abstract List<string> LoadHeaders();
 

--- a/TestUtil/DocumentLine.cs
+++ b/TestUtil/DocumentLine.cs
@@ -1,4 +1,6 @@
-﻿namespace Manx_Search_Data.TestUtil
+﻿using System;
+
+namespace Manx_Search_Data.TestUtil
 {
     public class DocumentLine
     {
@@ -9,6 +11,11 @@
         public string? Speaker { get; set; }
         public string Notes { get; set; }
         public int? Page { get; set; }
+
+        /// <summary>The line's own date, where it has one apart from its document's:
+        /// in a fragments collection (<see cref="NotesCitationDates"/>) each line
+        /// dates from its note's citation.</summary>
+        public DateTime? Date { get; set; }
         /// <summary>The language of the Manx column: "gv" unless the row is untranslated
         /// English/Latin/mixed matter. Read from the sparse `ManxColumnLanguage` CSV column;
         /// at load time "gv" replaces a blank/absent value.</summary>

--- a/TestUtil/DocumentLinePreparer.cs
+++ b/TestUtil/DocumentLinePreparer.cs
@@ -17,6 +17,11 @@ public static class DocumentLinePreparer
 {
     public static void Prepare(Document document, List<DocumentLine> lines)
     {
+        if (document.NotesCitations)
+        {
+            NotesCitationDates.Apply(document, lines);
+        }
+
         var speakerCode = BuildSpeakerCodeRegex(document.InlineSpeakerCodes);
 
         foreach (var line in lines)

--- a/TestUtil/NotesCitationDates.cs
+++ b/TestUtil/NotesCitationDates.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Manx_Search_Data.TestUtil;
+
+/// <summary>
+/// The dates of a fragments collection (<see cref="Document.NotesCitations"/>): a
+/// file like Brooillagh is one CSV of lines gleaned from many sources, each line's
+/// real source cited in its Notes cell ("[M.H., 05/05/1858]" - Mona's Herald;
+/// "[Mona Miscellany; ...; 1869]" for a book). The citation's date is the line's
+/// date; a line without one (the rest of a quoted song, or a prose note) belongs
+/// to the last cited fragment. The collection's own date range is then the span
+/// of its lines - without this, every 1794 attestation would carry the year the
+/// transcription was typed up.
+/// </summary>
+/// <remarks>Copied 1:1 from manx-corpus-search (CorpusSearch/Model/NotesCitationDates.cs)
+/// so this repository lints citations against the exact semantics production loads
+/// them with</remarks>
+public static class NotesCitationDates
+{
+    /// <summary>"05/05/1858" (day first) anywhere in the note: the citation's full
+    /// date. A doubled slash ("07/01//1880") reads the same: the citations are
+    /// parsed as their transcriber wrote them, slips included - the file is not
+    /// made to churn for the reader's benefit.</summary>
+    private static readonly Regex SlashedDate = new(@"\b(\d{1,2})/(\d{1,2})/{1,2}(\d{4})\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>The file's other slip: the second slash missing entirely, fusing
+    /// month and year ("23/051868", "17/101877" - 23/05/1868, 17/10/1877)</summary>
+    private static readonly Regex FusedDate = new(@"\b(\d{1,2})/(\d{2})(\d{4})\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>A plausible bare year ("... Manx Society Vol. XVI; 1869"): book
+    /// citations date to a year, not a day</summary>
+    private static readonly Regex BareYear = new(@"\b(1[5-9]\d\d|20\d\d)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>A day/month fragment: a note containing one means a full date was
+    /// intended, so <see cref="Parse"/> failing over it is a citation typo</summary>
+    private static readonly Regex DateFragment = new(@"\d{1,2}/\d{1,2}",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>The citation's date: the last full day/month/year in the note, else
+    /// the last bare year (a book cites no day), else null (a prose note, or none).
+    /// The last, not the first: prose may precede the citation
+    /// ("[... said to have run aground ... [M.H., 01/01/1896]").</summary>
+    public static DateTime? Parse(string? note)
+    {
+        if (string.IsNullOrWhiteSpace(note))
+        {
+            return null;
+        }
+
+        var fullDate = ParseFullDate(note);
+        if (fullDate != null)
+        {
+            return fullDate;
+        }
+
+        Match? lastYear = null;
+        foreach (Match match in BareYear.Matches(note))
+        {
+            lastYear = match;
+        }
+        return lastYear == null ? null : new DateTime(int.Parse(lastYear.Value), 1, 1);
+    }
+
+    /// <summary>The last day/month/year in the note which is a real calendar date;
+    /// 31/02/1858 is no date at all, and is left for the lint</summary>
+    private static DateTime? ParseFullDate(string note)
+    {
+        int lastIndex = -1;
+        DateTime? last = null;
+        foreach (var regex in new[] { SlashedDate, FusedDate })
+        {
+            foreach (Match match in regex.Matches(note))
+            {
+                int day = int.Parse(match.Groups[1].Value);
+                int month = int.Parse(match.Groups[2].Value);
+                int year = int.Parse(match.Groups[3].Value);
+                if (month is >= 1 and <= 12 && day >= 1 && day <= DateTime.DaysInMonth(year, month)
+                    && match.Index > lastIndex)
+                {
+                    lastIndex = match.Index;
+                    last = new DateTime(year, month, day);
+                }
+            }
+        }
+        return last;
+    }
+
+    /// <summary>Whether the note contains a day/month fragment yet no valid full
+    /// date: a mistyped citation which would otherwise silently date the line to
+    /// the previous fragment, or fall back to its bare year. The lint fails on
+    /// these.</summary>
+    public static bool LooksDatedButUnparsed(string? note)
+    {
+        return !string.IsNullOrWhiteSpace(note)
+               && DateFragment.IsMatch(note)
+               && ParseFullDate(note) == null;
+    }
+
+    /// <summary>
+    /// Dates each line from its note's citation, lines without one inheriting the
+    /// last cited date, and settles the collection's own date range to the span of
+    /// its lines (a manifest "created" - the transcription date - is overridden:
+    /// the fragments are older than their typing-up).
+    /// </summary>
+    public static void Apply(Document document, IEnumerable<DocumentLine> lines)
+    {
+        DateTime? current = null;
+        DateTime? earliest = null;
+        DateTime? latest = null;
+        foreach (var line in lines)
+        {
+            current = Parse(line.Notes) ?? current;
+            line.Date = current;
+            if (current == null)
+            {
+                continue;
+            }
+            earliest = earliest == null || current < earliest ? current : earliest;
+            latest = latest == null || current > latest ? current : latest;
+        }
+
+        if (earliest != null)
+        {
+            document.CreatedCircaStart = earliest;
+            document.CreatedCircaEnd = latest;
+        }
+    }
+}


### PR DESCRIPTION
The manifest's 2026 "created" was the transcription's date, not the fragments': "notesCitations" replaces it, and manx-corpus-search now dates each line from the citation in its Notes cell. The mirrored parser and NotesCitationTests keep every citation readable as written